### PR TITLE
Fix bug: Content-Type don't support charset

### DIFF
--- a/background.js
+++ b/background.js
@@ -216,7 +216,7 @@ function sendAjax(req, successFn, errorFn) {
 	req.headers = req.headers || {};
 
 	if (req.method.toLowerCase() !== 'get' && req.method.toLowerCase() !== 'head' && req.method.toLowerCase() !== 'options') {
-		if (!req.headers['Content-Type'] || req.headers['Content-Type'] == 'application/x-www-form-urlencoded') {
+		if (!req.headers['Content-Type'] || req.headers['Content-Type'].startsWith('application/x-www-form-urlencoded')) {
 			req.headers['Content-Type'] = req.headers['Content-Type'] || 'application/x-www-form-urlencoded';
 			req.data = formUrlencode(req.data);
 		} else if (typeof req.data === 'object' && req.data) {

--- a/background.js
+++ b/background.js
@@ -217,7 +217,7 @@ function sendAjax(req, successFn, errorFn) {
 
 	if (req.method.toLowerCase() !== 'get' && req.method.toLowerCase() !== 'head' && req.method.toLowerCase() !== 'options') {
 		if (!req.headers['Content-Type'] || req.headers['Content-Type'] == 'application/x-www-form-urlencoded') {
-			req.headers['Content-Type'] = 'application/x-www-form-urlencoded';
+			req.headers['Content-Type'] = req.headers['Content-Type'] || 'application/x-www-form-urlencoded';
 			req.data = formUrlencode(req.data);
 		} else if (typeof req.data === 'object' && req.data) {
 			req.data = JSON.stringify(req.data);


### PR DESCRIPTION
Chrome插件中有个问题，某些时间，Context-Type必须要带上charset否则中文解析会有问题，例如：Content-Type	application/x-www-form-urlencoded;charset="UTF-8"，但是插件这个判断是不支持的，因此加上判断，优先使用用户自定义的Context-Type
